### PR TITLE
Remove deprecated static files configuration from Beanstalk

### DIFF
--- a/packages/registry/.ebextensions/02_node_settings.config
+++ b/packages/registry/.ebextensions/02_node_settings.config
@@ -13,7 +13,3 @@ option_settings:
     NODE_ENV: "production"
     NPM_USE_PRODUCTION: "true"
     NPM_CONFIG_PRODUCTION: "true"
-
-  # Process management
-  aws:elasticbeanstalk:container:nodejs:staticfiles:
-    /public: "public"


### PR DESCRIPTION
Remove aws:elasticbeanstalk:container:nodejs:staticfiles configuration which is not supported in modern Node.js platforms and causes deployment errors. Static file serving is handled by nginx configuration instead.

Fixes: ConfigurationValidationException: Unknown configuration setting