### PR TITLE
Remove unsupported NodeVersion parameter from Beanstalk config

### DIFF
--- a/packages/registry/.ebextensions/02_node_settings.config
+++ b/packages/registry/.ebextensions/02_node_settings.config
@@ -4,7 +4,6 @@ option_settings:
   # Node.js platform settings
   aws:elasticbeanstalk:container:nodejs:
     NodeCommand: "npm start"
-    NodeVersion: "20"
     ProxyServer: "nginx"
     GzipCompression: "true"
 


### PR DESCRIPTION
NodeVersion is not supported in modern Elastic Beanstalk Node.js platforms. The Node.js version is determined by the platform version selection in the Beanstalk environment, not by .ebextensions configuration.

Fixes: ConfigurationValidationException: Unknown or duplicate parameter