### PR TITLE
Add logo version without text and use it in webapp

### DIFF
--- a/packages/webapp/public/logo-icon.svg
+++ b/packages/webapp/public/logo-icon.svg
@@ -1,0 +1,51 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background circle with gradient -->
+  <circle cx="256" cy="256" r="256" fill="url(#bgGradient)"/>
+
+  <!-- Gradient definitions -->
+  <defs>
+    <linearGradient id="bgGradient" x1="0" y1="0" x2="512" y2="512" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" style="stop-color:#1a1a2e"/>
+      <stop offset="100%" style="stop-color:#0f0f1e"/>
+    </linearGradient>
+    <linearGradient id="accentGradient" x1="0" y1="0" x2="512" y2="512" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" style="stop-color:#10b981"/>
+      <stop offset="50%" style="stop-color:#059669"/>
+      <stop offset="100%" style="stop-color:#047857"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Package box representation - 3D isometric style (centered without text) -->
+  <g transform="translate(256, 256)">
+    <!-- Top face -->
+    <path d="M 0,-80 L 100,-30 L 0,20 L -100,-30 Z" fill="url(#accentGradient)" opacity="0.9"/>
+
+    <!-- Left face -->
+    <path d="M -100,-30 L -100,90 L 0,140 L 0,20 Z" fill="#047857" opacity="0.7"/>
+
+    <!-- Right face -->
+    <path d="M 100,-30 L 100,90 L 0,140 L 0,20 Z" fill="#059669" opacity="0.8"/>
+
+    <!-- Ribbon/tape across the box -->
+    <rect x="-12" y="-60" width="24" height="200" fill="#34d399" opacity="0.6"/>
+
+    <!-- Vertical line detail -->
+    <line x1="0" y1="-80" x2="0" y2="140" stroke="#6ee7b7" stroke-width="4" opacity="0.8"/>
+  </g>
+
+  <!-- Accent dots for decoration -->
+  <circle cx="140" cy="140" r="8" fill="#10b981" opacity="0.3"/>
+  <circle cx="372" cy="140" r="8" fill="#10b981" opacity="0.3"/>
+  <circle cx="140" cy="372" r="8" fill="#10b981" opacity="0.3"/>
+  <circle cx="372" cy="372" r="8" fill="#10b981" opacity="0.3"/>
+
+  <!-- Grid pattern overlay for tech feel -->
+  <g opacity="0.05">
+    <line x1="128" y1="0" x2="128" y2="512" stroke="#ffffff" stroke-width="1"/>
+    <line x1="256" y1="0" x2="256" y2="512" stroke="#ffffff" stroke-width="1"/>
+    <line x1="384" y1="0" x2="384" y2="512" stroke="#ffffff" stroke-width="1"/>
+    <line x1="0" y1="128" x2="512" y2="128" stroke="#ffffff" stroke-width="1"/>
+    <line x1="0" y1="256" x2="512" y2="256" stroke="#ffffff" stroke-width="1"/>
+    <line x1="0" y1="384" x2="512" y2="384" stroke="#ffffff" stroke-width="1"/>
+  </g>
+</svg>

--- a/packages/webapp/src/app/(app)/layout.tsx
+++ b/packages/webapp/src/app/(app)/layout.tsx
@@ -14,7 +14,7 @@ export default function AppLayout({
           <div className="flex justify-between h-16 items-center">
             <div className="flex items-center gap-8">
               <Link href="/" className="flex items-center gap-3">
-                <Image src="/logo.svg" alt="PRPM Logo" width={40} height={40} className="w-10 h-10" />
+                <Image src="/logo-icon.svg" alt="PRPM Logo" width={40} height={40} className="w-10 h-10" />
                 <span className="text-2xl font-bold bg-gradient-to-r from-prpm-accent to-prpm-purple bg-clip-text text-transparent">
                   PRPM
                 </span>

--- a/packages/webapp/src/app/page.tsx
+++ b/packages/webapp/src/app/page.tsx
@@ -22,7 +22,7 @@ export default function Home() {
             </div>
 
             <div className="flex justify-center mb-8">
-              <Image src="/logo.svg" alt="PRPM Logo" width={120} height={120} className="w-24 h-24 lg:w-32 lg:h-32" />
+              <Image src="/logo-icon.svg" alt="PRPM Logo" width={120} height={120} className="w-24 h-24 lg:w-32 lg:h-32" />
             </div>
 
             <h1 className="text-7xl lg:text-8xl font-extrabold mb-6 tracking-tight">


### PR DESCRIPTION
- Created logo-icon.svg (centered package box without PRPM text)
- Updated navbar to use logo-icon.svg
- Updated landing page hero to use logo-icon.svg
- Kept original logo.svg with text for other uses

Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)