### PR TITLE
fix(blog): Add Nango.dev link and correct install path

### DIFF
--- a/packages/webapp/src/app/blog/distributable-intelligence/page.tsx
+++ b/packages/webapp/src/app/blog/distributable-intelligence/page.tsx
@@ -172,6 +172,8 @@ subtype: rule
 
 # Nango TypeScript Patterns
 
+Learn more at [Nango.dev](https://nango.dev)
+
 When converting YAML integrations:
 - YAML \`sync\` → TypeScript class extending \`NangoSync\`
 - \`models\` array → generic type \`NangoSync<Model>\`
@@ -183,7 +185,7 @@ When converting YAML integrations:
 
           <h3>3. Install & Apply</h3>
           <pre className="language-bash"><code>{`$ prpm install @nango/yaml-to-ts-migration-agent
-✓ Installed to .ai/nango/yaml-to-ts-migration-agent
+✓ Installed to .cursor/rules/nango/yaml-to-ts-migration-agent
 
 # In your AI assistant (Cursor/Claude/etc):
 "Migrate all YAML integrations to TypeScript"


### PR DESCRIPTION
## Summary

Fixes for the Distributable Intelligence blog post based on user feedback.

## Changes

1. **Added Nango.dev link** in the code example:
   ```markdown
   # Nango TypeScript Patterns
   
   Learn more at [Nango.dev](https://nango.dev)
   ```

2. **Corrected install path** from `.ai/` to `.cursor/rules/`:
   ```bash
   # Before
   ✓ Installed to .ai/nango/yaml-to-ts-migration-agent
   
   # After
   ✓ Installed to .cursor/rules/nango/yaml-to-ts-migration-agent
   ```

## Why

- Path `.cursor/rules/` matches actual Cursor directory structure
- Nango.dev link provides context for readers unfamiliar with Nango
- Makes the example more accurate and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>