### PR TITLE
fix(blog): Final styling polish - prominent headings and accurate directory refs

### DIFF
--- a/packages/webapp/src/app/blog/distributable-intelligence/page.tsx
+++ b/packages/webapp/src/app/blog/distributable-intelligence/page.tsx
@@ -480,7 +480,9 @@ subtype: rule
 
           <p className="text-xl font-semibold text-white">We're building the missing piece.</p>
 
-          <h2>Get Started</h2>
+          <div className="not-prose bg-gradient-to-r from-prpm-dark-card to-prpm-dark-card/50 border-l-4 border-prpm-accent rounded-r-2xl p-8 my-12">
+            <h2 className="text-3xl font-bold text-white mb-0">Get Started</h2>
+          </div>
 
           <div className="not-prose space-y-8">
             <div>


### PR DESCRIPTION
## Summary

Final round of styling improvements based on user feedback: "styling still not great"

## Changes

### 1. ✨ "In Two Minutes" Now Stands Out

**Before:** Plain H2 heading
**After:** Prominent accent-bordered box matching site design

```tsx
<div className="not-prose bg-gradient-to-r from-prpm-dark-card to-prpm-dark-card/50 
     border-l-4 border-prpm-accent rounded-r-2xl p-8 my-12">
  <h2 className="text-3xl font-bold text-white mb-6">In Two Minutes</h2>
  <p className="text-gray-300 leading-relaxed text-lg mb-0">...</p>
</div>
```

Now visually prominent like "In One Line" section above it.

### 2. ✨ "How It Works in 60 Seconds" - Prominent Header

**Before:** Plain H2 heading
**After:** Styled accent-bordered section header

```tsx
<div className="not-prose bg-gradient-to-r from-prpm-dark-card to-prpm-dark-card/50 
     border-l-4 border-prpm-accent rounded-r-2xl p-8 my-12">
  <h2 className="text-3xl font-bold text-white mb-0">How It Works in 60 Seconds</h2>
</div>
```

Major sections now have consistent visual hierarchy.

### 3. 📁 Directory References Updated

**Before:** `.ai/` (incorrect)
**After:** `.claude/` or `.cursor/` (accurate)

Changed text from:
> "their AI assistant loads it from `.ai/`"

To:
> "their AI assistant loads it from `.claude/` or `.cursor/`"

Reflects actual directory structures used by Claude and Cursor.

### 4. 💡 "house style" Emphasis

**Before:** Plain text
**After:** Bolded for emphasis

Highlights key concept in OSS maintainers benefit.

## Visual Impact

**Consistent Section Headers:**
- ✅ "In One Line" - Accent bordered box
- ✅ "In Two Minutes" - Accent bordered box (NEW)
- ✅ "How It Works in 60 Seconds" - Accent bordered box (NEW)

**Accurate Technical Details:**
- ✅ Correct directory references (.claude/, .cursor/)
- ✅ Emphasized key concepts (house style)

## Before/After

**Before:**
```
In Two Minutes

Codemods automate...
```

**After:**
```
┌─ In Two Minutes ──────────────
│ Codemods automate...
└───────────────────────────────
```
(Accent-bordered, gradient background)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>