### PR TITLE
fix(auth): separate incoming and stored Nango connection IDs

### DIFF
--- a/packages/registry/migrations/019_add_incoming_connection_id.sql
+++ b/packages/registry/migrations/019_add_incoming_connection_id.sql
@@ -1,0 +1,11 @@
+-- Add incoming_connection_id to users table
+-- This stores the NEW connection ID from Nango until we're ready to switch to it
+-- The stored nango_connection_id remains unchanged until we delete the old connection
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS incoming_connection_id VARCHAR(255);
+
+-- Add index for efficient lookups
+CREATE INDEX IF NOT EXISTS idx_users_incoming_connection_id ON users(incoming_connection_id);
+
+-- Add comment
+COMMENT ON COLUMN users.incoming_connection_id IS 'Temporary storage for new Nango connection ID until old connection is deleted';

--- a/packages/registry/src/types.ts
+++ b/packages/registry/src/types.ts
@@ -17,6 +17,7 @@ export interface User {
   avatar_url?: string;
   password_hash?: string;
   nango_connection_id?: string;
+  incoming_connection_id?: string | null;
   website?: string;
   verified_author: boolean;
   is_admin: boolean;


### PR DESCRIPTION
## Problem

The Nango connection logic was causing race conditions and authentication failures:
- Webhook immediately updated `nango_connection_id` when receiving a new connection
- Old connection was deleted before user callback could complete
- Users would lose authentication mid-flow

## Solution

Added a two-phase connection switching approach:

### 1. New Database Field: `incoming_connection_id`
- Stores the NEW connection ID temporarily
- The stored `nango_connection_id` remains unchanged until we're ready to switch

### 2. Updated Webhook Logic
- When a new connection is created → stores as `incoming_connection_id`
- Does NOT update `nango_connection_id` or delete old connection
- Old connection remains active

### 3. Updated Callback Logic
- Checks if callback's `connectionId` matches `incoming_connection_id`
- If it matches:
  1. Deletes old connection from Nango
  2. Switches `nango_connection_id` to new value
  3. Clears `incoming_connection_id`
- Atomic operation prevents race conditions

## Flow

```
1. User initiates new connection
   → Webhook stores as incoming_connection_id
   → nango_connection_id stays unchanged (old connection still active)

2. User completes authentication
   → Callback checks if connectionId matches incoming_connection_id
   → If yes: delete old, switch to new, clear incoming

3. Result: nango_connection_id only changes when we're ready
```

## Changes

- ✅ Migration 019: Add `incoming_connection_id` column
- ✅ Updated `User` type definition
- ✅ Webhook: Store incoming connection without switching
- ✅ Callback: Switch atomically when user authenticates

This ensures the old connection stays active until the new one is verified and the user has successfully authenticated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>