### PR TITLE
Update blog post: PRPM and Claude Plugins working together + Remove modal 'View Details' link

### DIFF
--- a/packages/webapp/src/app/blog/page.tsx
+++ b/packages/webapp/src/app/blog/page.tsx
@@ -25,11 +25,11 @@ interface BlogPost {
 const blogPosts: BlogPost[] = [
   {
     slug: "prpm-vs-plugins",
-    title: "PRPM vs Claude Plugins Marketplace: What's the Difference?",
-    excerpt: "Understanding how PRPM differs from the Claude plugin marketplaces. Learn why PRPM manages AI instructions while plugins manage executable code, and why both can coexist in your workflow.",
+    title: "PRPM and Claude Plugins: Working Together",
+    excerpt: "How PRPM complements Anthropic's Claude Code plugin system. Learn why cross-platform and platform-specific solutions strengthen the AI coding ecosystem.",
     date: "2025-10-27",
     author: "PRPM Team",
-    readTime: "5 min read",
+    readTime: "6 min read",
     tags: ["PRPM", "Explainer", "Vision"],
   },
   {

--- a/packages/webapp/src/app/blog/prpm-vs-plugins/page.tsx
+++ b/packages/webapp/src/app/blog/prpm-vs-plugins/page.tsx
@@ -5,8 +5,8 @@ import Tag from '@/components/Tag'
 import BlogPostHeader from '@/components/BlogPostHeader'
 
 export const metadata = {
-  title: 'PRPM vs Claude Plugins Marketplace: What\'s the Difference?',
-  description: 'Understanding how PRPM differs from traditional plugin marketplaces and why both can coexist in your AI coding workflow.',
+  title: 'PRPM and Claude Plugins: Working Together',
+  description: 'How PRPM complements Anthropic\'s Claude Code plugin system. Learn why cross-platform and platform-specific solutions strengthen the AI coding ecosystem.',
 }
 
 export default function PRPMvsPluginsPage() {
@@ -19,23 +19,23 @@ export default function PRPMvsPluginsPage() {
 
         <BlogPostHeader
           tags={['PRPM', 'Explainer', 'Vision']}
-          title="PRPM vs Claude Plugins Marketplace: What's the Difference?"
-          subtitle="Understanding how PRPM differs from traditional plugin marketplaces and why both can coexist in your AI coding workflow."
+          title="PRPM and Claude Plugins: Working Together"
+          subtitle="How PRPM complements Anthropic's Claude Code plugin system. Learn why cross-platform and platform-specific solutions strengthen the AI coding ecosystem."
           author="PRPM Team"
           date="October 27, 2024"
-          readTime="5 min read"
+          readTime="6 min read"
         />
 
         <article className="prose prose-invert prose-lg max-w-none">
-          <div className="bg-prpm-accent/10 border-l-4 border-prpm-accent rounded-r-lg p-6 mb-12">
-            <p className="text-lg font-semibold text-prpm-accent mb-2">TL;DR</p>
+          <div className="bg-blue-500/10 border-l-4 border-blue-500 rounded-r-lg p-6 mb-12">
+            <p className="text-lg font-semibold text-blue-400 mb-2">TL;DR</p>
             <p className="text-gray-300 mb-0">
-              Claude's plugins extend one environment with tool integrations. PRPM distributes AI knowledge across all of them as portable, version-controlled packages. They complement each other.
+              Anthropic's Claude Code plugins represent the future of AI environments—deeply integrated, elegantly designed, and optimized for Claude users. PRPM takes inspiration from that approach and extends it across the entire AI coding ecosystem for cross-platform compatibility. They work better together.
             </p>
           </div>
 
           <p className="text-xl text-gray-300 leading-relaxed mb-12">
-            One of the most common questions we get is: <strong>"Is PRPM just another plugins marketplace?"</strong> The short answer: No! While both help extend AI coding tools, they solve fundamentally different problems. Let's break it down.
+            One of the most common questions we get is: <strong>"Is PRPM just another plugins marketplace?"</strong> The short answer: We're complementary, not competing. Claude Code pioneered the structured AI package approach, and PRPM helps spread that pattern across all AI coding tools. Let's explore how they work together.
           </p>
 
           <h2 id="what-is-prpm" className="text-3xl font-bold text-white mt-12 mb-6 group scroll-mt-24">
@@ -69,32 +69,40 @@ export default function PRPMvsPluginsPage() {
 # Your AI now follows React best practices automatically`}</code>
           </pre>
 
-          <h2 id="what-is-a-plugins-marketplace" className="text-3xl font-bold text-white mt-16 mb-6 group scroll-mt-24">
-            <a href="#what-is-a-plugins-marketplace" className="inline-flex items-center gap-2 no-underline hover:no-underline">
-              What is a Plugins Marketplace?
+          <h2 id="what-is-claude-plugins" className="text-3xl font-bold text-white mt-16 mb-6 group scroll-mt-24">
+            <a href="#what-is-claude-plugins" className="inline-flex items-center gap-2 no-underline hover:no-underline">
+              What Are Claude Code Plugins?
               <span className="opacity-0 group-hover:opacity-100 transition-opacity text-prpm-accent text-xl">🔗</span>
             </a>
           </h2>
 
-          <div className="bg-prpm-dark-card border border-prpm-border rounded-lg p-6 my-8">
-            <p className="text-gray-300 font-semibold mb-2">Plugin marketplaces distribute:</p>
+          <p className="text-lg text-gray-300 mb-8">
+            <strong>Claude Code got it right.</strong> Anthropic built an elegant plugin system that recognized a fundamental truth: AI assistants need structured, shareable instruction packages, not just traditional IDE extensions.
+          </p>
+
+          <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-6 my-8">
+            <p className="text-blue-400 font-semibold mb-2">Claude Code's Plugin System includes:</p>
             <ul className="space-y-2 mb-0">
-              <li>💻 <strong>Extensible packages</strong> that bundle custom commands, agents, skills, MCP servers, and hooks</li>
-              <li>🔌 <strong>Tool-level extensions</strong> that install via <code>/plugin install</code> and toggle on/off as needed</li>
-              <li>⚙️ <strong>Curated catalogs</strong> where developers discover and share plugins</li>
-              <li>🛠️ <strong>Single-command deployment</strong> of multiple features at once</li>
+              <li>🎯 <strong>Skills</strong> — AI instructions and prompts that guide Claude's behavior</li>
+              <li>🤖 <strong>Agents</strong> — Multi-step task definitions for complex workflows</li>
+              <li>⚡ <strong>Commands</strong> — Reusable AI workflows triggered on demand</li>
+              <li>🔗 <strong>Hooks</strong> — Event-based triggers for contextual assistance</li>
+              <li>🛠️ <strong>MCP Servers</strong> — Optional tool integrations when needed</li>
             </ul>
             <p className="text-sm text-gray-400 mt-4 mb-0">
-              <strong>Note:</strong> Plugins can include the <strong>Model Context Protocol (MCP)</strong> to connect Claude to external data sources, APIs, and developer tools. Marketplaces can be public or organization-private.
+              Claude plugins are <strong>declarative packages</strong> distributed via JSON-based marketplaces. They're not traditional "plugins" in the executable code sense—they're structured AI instruction packages, which is a brilliant approach that prioritizes safety and simplicity.
             </p>
           </div>
 
-          <h3 className="text-xl font-semibold text-gray-200 mt-8 mb-4">Examples:</h3>
-          <ul className="space-y-3 mb-12">
-            <li><strong>Claude Code Plugin:</strong> Bundles slash commands, agents, MCP servers, and hooks together</li>
-            <li><strong>VSCode Extension:</strong> Adds UI panels, custom commands, syntax highlighting to VS Code</li>
-            <li><strong>MCP Server (standalone):</strong> Runs a background process for database access, file operations, etc.</li>
-          </ul>
+          <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-6 my-8">
+            <p className="text-blue-400 font-semibold mb-3">💡 Bridge Between Ecosystems:</p>
+            <p className="mb-2 text-gray-300">
+              We designed PRPM to work seamlessly with Claude Code's plugin format. If you already have a <code>.claude/marketplace.json</code> file, just run <code>prpm publish</code> and PRPM will automatically convert and publish your package—no extra work required.
+            </p>
+            <p className="mb-0 text-gray-300 text-sm">
+              This means you can publish to <em>both</em> Claude Code's marketplace (reaching Claude users) <em>and</em> PRPM (reaching users across all AI coding tools). We built this bridge intentionally to honor the great work Anthropic has done with Claude Code plugins.
+            </p>
+          </div>
 
           <h2 id="comparison" className="text-3xl font-bold text-white mt-16 mb-6 group scroll-mt-24">
             <a href="#comparison" className="inline-flex items-center gap-2 no-underline hover:no-underline">
@@ -104,44 +112,44 @@ export default function PRPMvsPluginsPage() {
           </h2>
 
           <div className="overflow-x-auto my-8">
-            <table className="w-full border-collapse">
+            <table className="w-full border-collapse text-sm">
               <thead>
                 <tr className="border-b border-prpm-border">
-                  <th className="text-left py-3 px-4 text-gray-300">Aspect</th>
-                  <th className="text-left py-3 px-4 text-prpm-accent">PRPM</th>
-                  <th className="text-left py-3 px-4 text-gray-300">Plugins Marketplace</th>
+                  <th className="text-left py-3 px-3 text-gray-300">Aspect</th>
+                  <th className="text-left py-3 px-3 text-blue-400">Claude Code Plugins</th>
+                  <th className="text-left py-3 px-3 text-prpm-accent">PRPM</th>
                 </tr>
               </thead>
               <tbody className="text-gray-300">
                 <tr className="border-b border-prpm-border/50">
-                  <td className="py-3 px-4 font-semibold">What</td>
-                  <td className="py-3 px-4">AI instructions (text/markdown)</td>
-                  <td className="py-3 px-4">Extension packages (manifests + configs)</td>
+                  <td className="py-3 px-3 font-semibold">What</td>
+                  <td className="py-3 px-3">AI instruction packages (Skills, Agents, Commands)</td>
+                  <td className="py-3 px-3">AI instructions (text/markdown files)</td>
                 </tr>
                 <tr className="border-b border-prpm-border/50">
-                  <td className="py-3 px-4 font-semibold">Where</td>
-                  <td className="py-3 px-4">Project directory (committed)</td>
-                  <td className="py-3 px-4">Global or project (toggle on/off)</td>
+                  <td className="py-3 px-3 font-semibold">Platform</td>
+                  <td className="py-3 px-3">Claude Code only (optimized integration)</td>
+                  <td className="py-3 px-3">Cross-platform (Cursor, Claude, Windsurf, Continue)</td>
                 </tr>
                 <tr className="border-b border-prpm-border/50">
-                  <td className="py-3 px-4 font-semibold">How</td>
-                  <td className="py-3 px-4">AI reads files directly</td>
-                  <td className="py-3 px-4">Claude loads and integrates</td>
+                  <td className="py-3 px-3 font-semibold">Where</td>
+                  <td className="py-3 px-3">Claude Code config (global or project)</td>
+                  <td className="py-3 px-3">Project directory (committed with code)</td>
                 </tr>
                 <tr className="border-b border-prpm-border/50">
-                  <td className="py-3 px-4 font-semibold">Format</td>
-                  <td className="py-3 px-4">Markdown, text files</td>
-                  <td className="py-3 px-4">JSON manifests + configs</td>
+                  <td className="py-3 px-3 font-semibold">Format</td>
+                  <td className="py-3 px-3">JSON manifests + markdown files</td>
+                  <td className="py-3 px-3">Markdown, text files (auto-converts)</td>
                 </tr>
                 <tr className="border-b border-prpm-border/50">
-                  <td className="py-3 px-4 font-semibold">Scope</td>
-                  <td className="py-3 px-4">Per-project</td>
-                  <td className="py-3 px-4">Global or per-project</td>
+                  <td className="py-3 px-3 font-semibold">Best For</td>
+                  <td className="py-3 px-3">Claude Code power users wanting deep integration</td>
+                  <td className="py-3 px-3">Teams using multiple AI tools</td>
                 </tr>
                 <tr>
-                  <td className="py-3 px-4 font-semibold">Git-Friendly</td>
-                  <td className="py-3 px-4">✅ Yes (commit with code)</td>
-                  <td className="py-3 px-4">✅ Yes (can commit to repo)</td>
+                  <td className="py-3 px-3 font-semibold">Distribution</td>
+                  <td className="py-3 px-3">Claude plugin marketplaces</td>
+                  <td className="py-3 px-3">Universal registry (prpm.dev)</td>
                 </tr>
               </tbody>
             </table>
@@ -155,42 +163,48 @@ export default function PRPMvsPluginsPage() {
           </h2>
 
           <div className="grid md:grid-cols-2 gap-6 my-10">
-            <div className="bg-prpm-accent/10 border border-prpm-accent/30 rounded-lg p-6">
-              <h3 className="text-prpm-accent text-xl font-bold mb-3 mt-0">PRPM is like npm/pip/gem</h3>
-              <p className="mb-0 text-gray-300">Installing <strong>libraries and dependencies</strong> for your project. They're code/text that your application uses.</p>
+            <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-6">
+              <h3 className="text-blue-400 text-xl font-bold mb-3 mt-0">Claude Code Plugins</h3>
+              <p className="text-sm mb-2 text-gray-300">Like <strong>App Store apps</strong></p>
+              <p className="mb-0 text-gray-300 text-sm">Curated, polished packages optimized for Claude Code. Pioneered the structured AI instruction approach. If you're all-in on Claude Code, this is your home.</p>
             </div>
-            <div className="bg-prpm-border/20 border border-prpm-border rounded-lg p-6">
-              <h3 className="text-gray-200 text-xl font-bold mb-3 mt-0">Plugins are like Chrome Extensions</h3>
-              <p className="mb-0 text-gray-300">Installing <strong>applications</strong> that extend the tool itself with new features and capabilities.</p>
+            <div className="bg-prpm-accent/10 border border-prpm-accent/30 rounded-lg p-6">
+              <h3 className="text-prpm-accent text-xl font-bold mb-3 mt-0">PRPM</h3>
+              <p className="text-sm mb-2 text-gray-300">Like <strong>npm/pip/gem</strong></p>
+              <p className="mb-0 text-gray-300 text-sm">Cross-platform package manager inspired by Claude Code's approach. Distributes AI instructions across Cursor, Claude, Windsurf, Continue, and more.</p>
             </div>
           </div>
 
           <h2 id="what-makes-prpm-special" className="text-3xl font-bold text-white mt-16 mb-6 group scroll-mt-24">
             <a href="#what-makes-prpm-special" className="inline-flex items-center gap-2 no-underline hover:no-underline">
-              What Makes PRPM Special?
+              How PRPM Complements Claude Code
               <span className="opacity-0 group-hover:opacity-100 transition-opacity text-prpm-accent text-xl">🔗</span>
             </a>
           </h2>
 
+          <p className="text-lg text-gray-300 mb-8">
+            Claude Code showed us that structured AI packages are the future. PRPM takes that insight and extends it to solve the cross-platform challenge.
+          </p>
+
           <div className="grid md:grid-cols-3 gap-6 my-10">
             <div className="bg-prpm-accent/10 border border-prpm-accent/30 rounded-lg p-6">
-              <h3 className="text-prpm-accent text-xl font-bold mb-4 mt-0">🌍 Cross-Platform Portability</h3>
+              <h3 className="text-prpm-accent text-xl font-bold mb-4 mt-0">🌍 Cross-Platform Bridge</h3>
               <p className="text-gray-300 mb-0">
-                Your AI setup isn't trapped inside a single tool. PRPM auto-converts packages between formats — install a Cursor rule and use it instantly in Claude Code, Windsurf, or Continue.
+                Your team uses Cursor, Claude Code, and Windsurf? PRPM auto-converts between formats so everyone gets the same instructions in their preferred tool. Claude pioneered the approach; PRPM spreads it across the ecosystem.
               </p>
             </div>
 
             <div className="bg-prpm-accent/10 border border-prpm-accent/30 rounded-lg p-6">
               <h3 className="text-prpm-accent text-xl font-bold mb-4 mt-0">📦 Familiar Workflow</h3>
               <p className="text-gray-300 mb-0">
-                <code>prpm install</code>, <code>prpm update</code>, <code>prpm search</code> — manage AI instructions like you manage dependencies. Version-controlled and committed with your code.
+                <code>prpm install</code>, <code>prpm update</code>, <code>prpm search</code> — the same workflow developers know from npm/pip. Version-controlled and committed with your code.
               </p>
             </div>
 
             <div className="bg-prpm-accent/10 border border-prpm-accent/30 rounded-lg p-6">
-              <h3 className="text-prpm-accent text-xl font-bold mb-4 mt-0">🚀 Centralized Discovery</h3>
+              <h3 className="text-prpm-accent text-xl font-bold mb-4 mt-0">🚀 Universal Discovery</h3>
               <p className="text-gray-300 mb-0">
-                One registry with <strong>1,500+ community packages</strong>. Search by tech stack, filter by ratings, browse curated collections — no hunting across scattered marketplaces.
+                One registry with <strong>1,500+ packages</strong> that work across all tools. Discover packages regardless of which AI coding assistant you use, with quality ratings and curated collections.
               </p>
             </div>
           </div>
@@ -316,7 +330,7 @@ prpm update`}</code>
         </article>
 
         <BlogFooter
-          postTitle="PRPM vs Plugins Marketplace: What's the Difference?"
+          postTitle="PRPM and Claude Plugins: Working Together"
           postUrl="/blog/prpm-vs-plugins"
         />
       </div>

--- a/packages/webapp/src/components/PackageModal.tsx
+++ b/packages/webapp/src/components/PackageModal.tsx
@@ -155,17 +155,10 @@ export default function PackageModal({ package: pkg, isOpen, onClose }: PackageM
         <div className="flex gap-3">
           <button
             onClick={handleCopyInstall}
-            className="flex-1 px-4 py-2 bg-prpm-accent hover:bg-prpm-accent-dark rounded-lg font-medium"
+            className="w-full px-4 py-2 bg-prpm-accent hover:bg-prpm-accent-dark rounded-lg font-medium"
           >
             {copied ? '✓ Copied!' : 'Copy Install Command'}
           </button>
-          <a
-            href={`/packages/${pkg.id}`}
-            className="px-4 py-2 bg-prpm-dark-card border border-prpm-border hover:border-prpm-accent rounded-lg font-medium text-center transition-colors"
-            onClick={(e) => e.stopPropagation()}
-          >
-            View Details
-          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Updates the PRPM vs plugins blog post to express humility and respect toward Anthropic's Claude Code plugin system, while still clearly communicating PRPM's value proposition.

Also removes the "View Details" link from the package modal on the search page.

## Blog Post Changes

### Tone & Positioning
- **Title**: "PRPM vs Claude Plugins Marketplace" → "PRPM and Claude Plugins: Working Together"
- **Opening**: Credits Claude Code for pioneering structured AI packages
- **Throughout**: Positions PRPM as complementary, not competing

### Key Updates
1. **TL;DR section**: Now emphasizes Claude plugins as "the future" with PRPM extending that vision across platforms
2. **Claude plugins section**: 
   - Opens with "Claude Code got it right"
   - Describes system as "elegant," "brilliant," and "declarative"
   - Details Skills, Agents, Commands, Hooks, MCP servers
3. **marketplace.json bridge**: Added callout explaining PRPM's native support for Claude's format
4. **Comparison table**: Reordered to put Claude first, shows complementary strengths
5. **Section renamed**: "What Makes PRPM Special?" → "How PRPM Complements Claude Code"

### What Stays
- Accurate technical information about both systems
- Clear explanation of cross-platform value
- Existing respectful closing quote about Anthropic

## Package Modal Change
- Removed "View Details" link from package modal
- "Copy Install Command" button now takes full width

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)