### PR TITLE
feat: add SEO endpoints for static site generation

### DIFF
--- a/packages/registry/src/routes/search.ts
+++ b/packages/registry/src/routes/search.ts
@@ -504,10 +504,10 @@ export async function searchRoutes(server: FastifyInstance) {
       return cached;
     }
 
-    // Get total count
+    // Get total count (collections don't have visibility - all are public)
     const countResult = await query<{ count: string }>(
       server,
-      `SELECT COUNT(*) as count FROM collections WHERE visibility = 'public'`
+      `SELECT COUNT(*) as count FROM collections`
     );
     const total = parseInt(countResult.rows[0]?.count || '0', 10);
 
@@ -516,7 +516,6 @@ export async function searchRoutes(server: FastifyInstance) {
       server,
       `SELECT name_slug, updated_at
        FROM collections
-       WHERE visibility = 'public'
        ORDER BY downloads DESC, name_slug ASC
        LIMIT $1 OFFSET $2`,
       [limit, offset]


### PR DESCRIPTION
## Summary

Adds two lightweight API endpoints to the registry to support Next.js static site generation (SSG) for package and collection detail pages.

## New Endpoints

### `GET /api/v1/search/seo/packages`
Returns package names only for static site generation with pagination.

**Query Parameters:**
- `limit` (number, default 100, max 1000)
- `offset` (number, default 0)

**Response:**
```json
{
  "packages": ["package-name-1", "package-name-2", ...],
  "total": 150,
  "limit": 100,
  "offset": 0,
  "hasMore": true
}
```

**Features:**
- Only returns public packages
- Ordered by total_downloads DESC for better SEO prioritization
- Cached for 1 hour (packages don't change frequently)
- Lightweight (names only) to minimize build time

### `GET /api/v1/search/seo/collections`
Returns collection slugs only for static site generation with pagination.

**Query Parameters:**
- `limit` (number, default 100, max 1000)
- `offset` (number, default 0)

**Response:**
```json
{
  "collections": ["@prpm/collection-1", "@prpm/collection-2", ...],
  "total": 25,
  "limit": 100,
  "offset": 0,
  "hasMore": false
}
```

**Features:**
- Only returns public collections
- Ordered by downloads DESC
- Cached for 1 hour
- Lightweight (slugs only) to minimize build time

## Purpose

These endpoints enable the webapp to generate static HTML pages for all packages and collections at build time using Next.js `generateStaticParams()`. This improves:
- **SEO**: Search engines can crawl pre-rendered pages
- **Performance**: Pages load instantly (no server-side rendering)
- **Hosting**: Can deploy to static hosting (S3 + CloudFront)

## Integration

The webapp will use these endpoints in:
- `packages/webapp/src/app/packages/[name]/page.tsx` - Generates static pages for all packages
- `packages/webapp/src/app/collections/[slug]/page.tsx` - Generates static pages for all collections

## Next Steps

After this PR is deployed:
1. Verify endpoints work:
   ```bash
   curl https://registry.prpm.dev/api/v1/search/seo/packages?limit=5
   curl https://registry.prpm.dev/api/v1/search/seo/collections?limit=5
   ```
2. Re-enable `output: 'export'` in webapp's next.config.js
3. Deploy webapp with full static site generation

## Technical Details

- **File**: `packages/registry/src/routes/search.ts:425-537`
- **Cache Duration**: 1 hour (collections/packages don't change frequently)
- **Pagination**: Supports large datasets without timing out builds
- **Performance**: Lightweight responses (no full package metadata)