### PR TITLE
fix: remove view details link from collection modal

### DIFF
--- a/packages/webapp/src/components/CollectionModal.tsx
+++ b/packages/webapp/src/components/CollectionModal.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import Link from 'next/link'
 
 interface CollectionPackage {
   packageId: string
@@ -220,13 +219,6 @@ export default function CollectionModal({ collection: initialCollection, isOpen,
           </code>
         </div>
 
-        {/* View Details Button */}
-        <Link
-          href={`/collections/${collection.name_slug}`}
-          className="block w-full text-center px-4 py-3 bg-prpm-accent hover:bg-prpm-accent-dark text-white rounded-lg font-medium transition-colors"
-        >
-          View Full Details
-        </Link>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Removed the "View Full Details" button from the collection modal
- Removed unused `Link` import from next/link

## Test plan
- [ ] Open the collections page
- [ ] Click on a collection to open the modal
- [ ] Verify the "View Full Details" button is no longer present
- [ ] Verify all other modal functionality works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)