### PR TITLE
fix: Quote environment variable URLs in deploy workflow YAML

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -370,9 +370,9 @@ jobs:
           npm run build:static
         env:
           CI: false
-          NEXT_PUBLIC_REGISTRY_URL: https://registry.prpm.dev
-          REGISTRY_URL: https://registry.prpm.dev
-          NEXT_PUBLIC_S3_SEO_DATA_URL: https://prpm-prod-packages.s3.amazonaws.com/seo-data
+          NEXT_PUBLIC_REGISTRY_URL: "https://registry.prpm.dev"
+          REGISTRY_URL: "https://registry.prpm.dev"
+          NEXT_PUBLIC_S3_SEO_DATA_URL: "https://prpm-prod-packages.s3.amazonaws.com/seo-data"
 
       - name: Verify build output
         run: |


### PR DESCRIPTION
Fixes YAML syntax error on line 380 by properly quoting URL values in the env section. GitHub Actions requires URLs with colons to be quoted to avoid YAML parsing issues.

**Changes:**
- Quoted `NEXT_PUBLIC_REGISTRY_URL`
- Quoted `REGISTRY_URL`  
- Quoted `NEXT_PUBLIC_S3_SEO_DATA_URL`

**Testing:**
- GitHub Actions YAML validation should now pass
- No functional changes, just proper YAML syntax