### PR TITLE
Fix: Allow authenticated org members to access private packages

### DIFF
--- a/packages/registry/src/routes/packages.ts
+++ b/packages/registry/src/routes/packages.ts
@@ -9,6 +9,7 @@ import { cacheGet, cacheSet, cacheDelete, cacheDeletePattern } from '../cache/re
 import { Package, PackageVersion, PackageInfo } from '../types.js';
 import { toError } from '../types/errors.js';
 import { config } from '../config.js';
+import { optionalAuth } from '../middleware/auth.js';
 import type {
   ListPackagesQuery,
   PackageParams,
@@ -166,6 +167,7 @@ export async function packageRoutes(server: FastifyInstance) {
 
   // Get package by ID
   server.get('/:packageName', {
+    onRequest: [optionalAuth],
     schema: {
       tags: ['packages'],
       description: 'Get package details by ID',
@@ -178,23 +180,44 @@ export async function packageRoutes(server: FastifyInstance) {
     },
   }, async (request: FastifyRequest, reply: FastifyReply) => {
     const { packageName: rawPackageName } = request.params as { packageName: string };
+    const userId = request.user?.user_id;
 
     // Decode URL-encoded package name (handles slashes in scoped packages)
     const packageName = decodeURIComponent(rawPackageName);
 
-    // Check cache
+    // Check cache (skip cache for authenticated requests to private packages)
     const cacheKey = `package:${packageName}`;
-    const cached = await cacheGet<PackageInfo>(server, cacheKey);
-    if (cached) {
-      return cached;
+    if (!userId) {
+      const cached = await cacheGet<PackageInfo>(server, cacheKey);
+      if (cached) {
+        return cached;
+      }
     }
 
-    // Get package
-    const pkg = await queryOne<Package>(
-      server,
-      `SELECT * FROM packages WHERE name = $1 AND visibility = 'public'`,
-      [packageName]
-    );
+    // Get package - include private packages if user is authenticated and has access
+    let pkg: Package | null = null;
+
+    if (userId) {
+      // For authenticated users, check if they have access to private packages
+      pkg = await queryOne<Package>(
+        server,
+        `SELECT p.* FROM packages p
+         LEFT JOIN organization_members om ON p.org_id = om.org_id AND om.user_id = $2
+         WHERE p.name = $1
+         AND (p.visibility = 'public'
+              OR (p.visibility = 'private'
+                  AND p.org_id IS NOT NULL
+                  AND om.user_id IS NOT NULL))`,
+        [packageName, userId]
+      );
+    } else {
+      // For unauthenticated users, only show public packages
+      pkg = await queryOne<Package>(
+        server,
+        `SELECT * FROM packages WHERE name = $1 AND visibility = 'public'`,
+        [packageName]
+      );
+    }
 
     if (!pkg) {
       return reply.status(404).send({ error: 'Package not found' });
@@ -233,14 +256,17 @@ export async function packageRoutes(server: FastifyInstance) {
       latest_version: transformedVersions[0],
     };
 
-    // Cache for 5 minutes
-    await cacheSet(server, cacheKey, packageInfo, 300);
+    // Only cache public packages (private packages should not be cached)
+    if (pkg.visibility === 'public') {
+      await cacheSet(server, cacheKey, packageInfo, 300);
+    }
 
     return packageInfo;
   });
 
   // Get specific package version
   server.get('/:packageName/:version', {
+    onRequest: [optionalAuth],
     schema: {
       tags: ['packages'],
       description: 'Get specific package version',
@@ -254,6 +280,7 @@ export async function packageRoutes(server: FastifyInstance) {
     },
   }, async (request: FastifyRequest, reply: FastifyReply) => {
     const { packageName: rawPackageName, version: versionParam } = request.params as { packageName: string; version: string };
+    const userId = request.user?.user_id;
 
     // Decode URL-encoded package name (handles slashes in scoped packages)
     const packageName = decodeURIComponent(rawPackageName);
@@ -265,18 +292,46 @@ export async function packageRoutes(server: FastifyInstance) {
       // Check if packageName is a UUID (for tarball downloads by ID)
       const isUUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(packageName);
 
-      // Get package version with content
-      const pkgVersion = await queryOne<PackageVersion>(
-        server,
-        isUUID
-          ? `SELECT pv.*, p.name as package_name FROM package_versions pv
-             JOIN packages p ON p.id = pv.package_id
-             WHERE p.id = $1 AND pv.version = $2 AND p.visibility = 'public'`
-          : `SELECT pv.*, p.name as package_name FROM package_versions pv
-             JOIN packages p ON p.id = pv.package_id
-             WHERE p.name = $1 AND pv.version = $2 AND p.visibility = 'public'`,
-        [packageName, version]
-      );
+      // Get package version with content - include private packages if user has access
+      let pkgVersion: PackageVersion | null = null;
+
+      if (userId) {
+        // For authenticated users, check if they have access to private packages
+        pkgVersion = await queryOne<PackageVersion>(
+          server,
+          isUUID
+            ? `SELECT pv.*, p.name as package_name FROM package_versions pv
+               JOIN packages p ON p.id = pv.package_id
+               LEFT JOIN organization_members om ON p.org_id = om.org_id AND om.user_id = $3
+               WHERE p.id = $1 AND pv.version = $2
+               AND (p.visibility = 'public'
+                    OR (p.visibility = 'private'
+                        AND p.org_id IS NOT NULL
+                        AND om.user_id IS NOT NULL))`
+            : `SELECT pv.*, p.name as package_name FROM package_versions pv
+               JOIN packages p ON p.id = pv.package_id
+               LEFT JOIN organization_members om ON p.org_id = om.org_id AND om.user_id = $3
+               WHERE p.name = $1 AND pv.version = $2
+               AND (p.visibility = 'public'
+                    OR (p.visibility = 'private'
+                        AND p.org_id IS NOT NULL
+                        AND om.user_id IS NOT NULL))`,
+          [packageName, version, userId]
+        );
+      } else {
+        // For unauthenticated users, only show public packages
+        pkgVersion = await queryOne<PackageVersion>(
+          server,
+          isUUID
+            ? `SELECT pv.*, p.name as package_name FROM package_versions pv
+               JOIN packages p ON p.id = pv.package_id
+               WHERE p.id = $1 AND pv.version = $2 AND p.visibility = 'public'`
+            : `SELECT pv.*, p.name as package_name FROM package_versions pv
+               JOIN packages p ON p.id = pv.package_id
+               WHERE p.name = $1 AND pv.version = $2 AND p.visibility = 'public'`,
+          [packageName, version]
+        );
+      }
 
       if (!pkgVersion) {
         return reply.status(404).send({ error: 'Package version not found' });
@@ -362,20 +417,41 @@ export async function packageRoutes(server: FastifyInstance) {
     // Regular version info request
     const version = versionParam;
 
-    // Check cache
+    // Check cache (skip cache for authenticated requests to private packages)
     const cacheKey = `package:${packageName}:${version}`;
-    const cached = await cacheGet<PackageVersion>(server, cacheKey);
-    if (cached) {
-      return cached;
+    if (!userId) {
+      const cached = await cacheGet<PackageVersion>(server, cacheKey);
+      if (cached) {
+        return cached;
+      }
     }
 
-    const pkgVersion = await queryOne<PackageVersion>(
-      server,
-      `SELECT pv.* FROM package_versions pv
-       JOIN packages p ON p.id = pv.package_id
-       WHERE p.name = $1 AND pv.version = $2 AND p.visibility = 'public'`,
-      [packageName, version]
-    );
+    let pkgVersion: PackageVersion | null = null;
+
+    if (userId) {
+      // For authenticated users, check if they have access to private packages
+      pkgVersion = await queryOne<PackageVersion>(
+        server,
+        `SELECT pv.*, p.visibility FROM package_versions pv
+         JOIN packages p ON p.id = pv.package_id
+         LEFT JOIN organization_members om ON p.org_id = om.org_id AND om.user_id = $3
+         WHERE p.name = $1 AND pv.version = $2
+         AND (p.visibility = 'public'
+              OR (p.visibility = 'private'
+                  AND p.org_id IS NOT NULL
+                  AND om.user_id IS NOT NULL))`,
+        [packageName, version, userId]
+      );
+    } else {
+      // For unauthenticated users, only show public packages
+      pkgVersion = await queryOne<PackageVersion>(
+        server,
+        `SELECT pv.* FROM package_versions pv
+         JOIN packages p ON p.id = pv.package_id
+         WHERE p.name = $1 AND pv.version = $2 AND p.visibility = 'public'`,
+        [packageName, version]
+      );
+    }
 
     if (!pkgVersion) {
       return reply.status(404).send({ error: 'Package version not found' });
@@ -390,8 +466,10 @@ export async function packageRoutes(server: FastifyInstance) {
       pkgVersion.tarball_url = `${baseUrl}/api/v1/packages/${encodedPackageName}/${pkgVersion.version}.tar.gz`;
     }
 
-    // Cache for 1 hour (versions are immutable)
-    await cacheSet(server, cacheKey, pkgVersion, 3600);
+    // Only cache public packages (private packages should not be cached)
+    if ((pkgVersion as any).visibility === 'public') {
+      await cacheSet(server, cacheKey, pkgVersion, 3600);
+    }
 
     return pkgVersion;
   });


### PR DESCRIPTION
## Summary
- Fixed private organization packages returning 404 errors for authenticated org members
- Added authentication support to package GET endpoints
- Modified queries to check organization membership for private package access

## Problem
When attempting to install private packages from an organization (e.g., `@prpm/prpm-development`), authenticated users who were valid members of the organization would receive "Package not found" errors. The error occurred because the API endpoints were hardcoded to only return packages with `visibility = 'public'`, completely ignoring user authentication and organization membership.

## Solution
1. **Added `optionalAuth` middleware** to GET package endpoints (`/:packageName` and `/:packageName/:version`)
   - Attempts authentication but doesn't fail if no token is provided
   - Preserves backward compatibility for public packages

2. **Enhanced SQL queries** with organization membership checks
   - Added LEFT JOIN with `organization_members` table
   - Returns private packages when user is authenticated AND is a member of the package's organization
   - Maintains existing behavior for unauthenticated users (public packages only)

3. **Updated caching logic**
   - Private packages are excluded from cache to maintain security
   - Prevents accidental leaking of private package data through shared cache

## Changes
- Modified `packages/registry/src/routes/packages.ts`:
  - Imported `optionalAuth` middleware
  - Updated GET `/:packageName` endpoint with auth check and org membership query
  - Updated GET `/:packageName/:version` endpoint (both tarball download and version info)
  - Added conditional caching based on package visibility

## Test Plan
- [ ] Deploy to staging/test environment
- [ ] Verify authenticated org member can install private org packages
- [ ] Verify unauthenticated users still get 404 for private packages  
- [ ] Verify public packages still work for all users
- [ ] Verify private packages are not cached
- [ ] Test with the reported failing package: `prpm install @prpm/prpm-development`

## Security Considerations
- Private packages are only accessible to authenticated organization members
- Package visibility is checked at query level, not application level
- Private packages are excluded from Redis cache to prevent data leakage
- No changes to authentication or authorization mechanisms

🤖 Generated with [Claude Code](https://claude.com/claude-code)