### PR TITLE
fix: update homepage collection to working essential-dev-agents

### DIFF
--- a/packages/webapp/src/app/page.tsx
+++ b/packages/webapp/src/app/page.tsx
@@ -88,7 +88,7 @@ export default function Home() {
                   <button className="text-xs text-gray-500 hover:text-prpm-accent transition-colors">Copy</button>
                 </div>
                 <code className="block font-mono text-prpm-accent-light text-left space-y-1">
-                  <div><span className="text-gray-600">$</span> prpm install essential-dev-agents</div>
+                  <div><span className="text-gray-600">$</span> prpm install collections/essential-dev-agents</div>
                   <div className="text-xs text-gray-500 mt-2"># Installs 20 packages: backend-architect, cloud-architect, database-architect, and more</div>
                 </code>
               </div>


### PR DESCRIPTION
## Summary
- Replace non-working `nextjs-pro` collection with `essential-dev-agents` collection
- Verified `essential-dev-agents` installs successfully with all 20 packages
- Updated homepage example to showcase a working collection

## Test plan
- [x] Searched available collections using `prpm collections search`
- [x] Tested `essential-dev-agents` installation - all 20 packages installed successfully
- [x] Updated homepage to use the working collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)