### PR TITLE
fix: correct broken internal links in advanced docs

### DIFF
--- a/public-documentation/advanced/meta-packages.mdx
+++ b/public-documentation/advanced/meta-packages.mdx
@@ -506,5 +506,5 @@ prpm publish
 ## Related Topics
 
 - [Self-Improving Packages](/advanced/self-improving-packages)
-- [Creating Skills Guide](/guides/creating-skills)
-- [Package Quality Standards](/guides/quality-standards)
+- [Package Formats](/concepts/formats)
+- [Publishing Guide](/publishing/getting-started)

--- a/public-documentation/advanced/self-improving-packages.mdx
+++ b/public-documentation/advanced/self-improving-packages.mdx
@@ -252,4 +252,4 @@ prpm install @prpm/typescript-type-safety
 
 - [Creating Meta Packages](/advanced/meta-packages)
 - [Package Collections](/cli/workflows#working-with-collections)
-- [AI Prompt Formats](/guides/formats)
+- [AI Prompt Formats](/concepts/formats)


### PR DESCRIPTION
## Summary

Fixes broken internal links in the advanced documentation that were causing 404s.

### Changes
- Fixed  →  in self-improving-packages.mdx
- Replaced non-existent guide links in meta-packages.mdx Related Topics section
- Now links to existing pages: Package Formats and Publishing Guide

### Root Cause
The advanced docs were linking to guides that don't exist yet (, ). Mintlify likely failed to build/validate these pages due to broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)