### PR TITLE
docs: update README to prominently feature docs.prpm.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ prpm install collection/nextjs-pro  # Entire Next.js setup in one command
 
 **1,800+ packages** | **Works everywhere** (Cursor, Claude, Continue, Windsurf, GitHub Copilot, Kiro) | **One command to install**
 
+📚 **[Official Documentation](https://docs.prpm.dev)** | 🌐 **[Browse Packages](https://prpm.dev)**
+
 ---
 
 ## 📦 Collections - Complete Setups in One Command
@@ -87,7 +89,7 @@ prpm collections info collection/nextjs-pro
 
 **Smart filters:** Category, tags, editor type, trending vs popular, official vs community
 
-**[Full CLI Reference →](docs/CLI.md)**
+📚 **[Full Documentation](https://docs.prpm.dev)** | **[CLI Reference](https://docs.prpm.dev/cli/overview)**
 
 ---
 
@@ -163,7 +165,7 @@ prpm install @username/karen-skill --as claude
 - **Continue**: Prompts ready to use
 - **Windsurf**: Rules integrated automatically
 
-**[Full Installation Guide →](docs/INSTALLATION.md)** | **[Configuration Guide →](docs/CONFIGURATION.md)**
+📚 **[Installation Guide](https://docs.prpm.dev/getting-started/installation)** | **[Configuration Guide](https://docs.prpm.dev/getting-started/configuration)**
 
 ---
 
@@ -177,7 +179,7 @@ prpm install @username/karen-skill --as claude
 
 **Categories:** Frontend frameworks, Backend frameworks, Programming languages, Testing, Mobile development, Cloud & DevOps, AI & ML, Databases, Web3, Best practices, and more
 
-**[Package Catalog →](docs/PACKAGES.md)** | **[Browse at prpm.dev →](https://prpm.dev/search)**
+🌐 **[Browse Packages](https://prpm.dev/search)** | 📚 **[Documentation](https://docs.prpm.dev)**
 
 ---
 
@@ -204,7 +206,7 @@ prpm trending                        # Trending packages
 prpm info <package-name>             # Package details
 ```
 
-**[Full CLI Reference →](docs/CLI.md)**
+📚 **[Full CLI Reference](https://docs.prpm.dev/cli/commands)** | **[All Documentation](https://docs.prpm.dev)**
 
 ---
 
@@ -234,7 +236,7 @@ prpm install @username/karen-skill
 # Get: 78/100 score + market research + actionable fixes
 ```
 
-**[More Examples →](docs/EXAMPLES.md)**
+📚 **[More Examples & Tutorials](https://docs.prpm.dev/guides/usage-examples)**
 
 ---
 
@@ -258,7 +260,7 @@ prpm install @username/karen-skill
 - **Version locking** - prpm-lock.json for consistent installs
 - **Collections** - Install multiple packages as bundles
 
-**[Architecture Details →](docs/ARCHITECTURE.md)**
+📚 **[Learn More](https://docs.prpm.dev/concepts/how-it-works)**
 
 ---
 
@@ -329,46 +331,34 @@ Contact [@khaliqgant](https://github.com/khaliqgant) for publishing access.
 
 ## Documentation
 
-### 📚 User Documentation
+### 📚 Official Documentation
 
-**Get Started:**
-- 📖 **[User Docs Index](docs/)** - Complete user documentation
-- 📦 [Installation Guide](docs/INSTALLATION.md)
-- ⚙️ [Configuration Guide](docs/CONFIGURATION.md) - ~/.prpmrc, prpm.lock, format customization
-- 💻 [CLI Reference](docs/CLI.md) - Complete command reference
+**➡️ [docs.prpm.dev](https://docs.prpm.dev) - Complete documentation**
 
-**Core Concepts:**
-- 📚 [Collections](docs/COLLECTIONS.md) - Multi-package bundles
-- 🔄 [Format Conversion](docs/FORMAT_CONVERSION.md) - Universal packages explained
-- 📦 [Packages](docs/PACKAGES.md) - Package catalog
-- 🎯 [Examples](docs/EXAMPLES.md) - Real-world usage
+**Quick Links:**
+- 🚀 [Getting Started](https://docs.prpm.dev/getting-started/installation) - Install and configure PRPM
+- 💻 [CLI Reference](https://docs.prpm.dev/cli/commands) - All commands and options
+- 📦 [Collections Guide](https://docs.prpm.dev/concepts/collections) - Multi-package bundles
+- 🔄 [Format Conversion](https://docs.prpm.dev/concepts/format-conversion) - Universal packages explained
+- 🎯 [Usage Examples](https://docs.prpm.dev/guides/usage-examples) - Real-world workflows
+- 🔌 [MCP Servers](https://docs.prpm.dev/guides/mcp-servers) - Model Context Protocol configuration
 
-**Advanced:**
-- 🏗️ [Architecture](docs/ARCHITECTURE.md) - System design
-- 🔌 [MCP Servers](docs/MCP_SERVERS_IN_COLLECTIONS.md) - MCP configuration
-- 📝 [Publishing](docs/PUBLISHING.md) - Publish your packages
-
-**Format-Specific Guides:**
-- ✈️ [GitHub Copilot](docs/GITHUB_COPILOT.md) - Instructions for GitHub Copilot
-- 🎯 [Kiro](docs/KIRO.md) - Steering files for Kiro AI
-- 🌊 [Windsurf](docs/WINDSURF.md) - Rules for Windsurf editor
-
-### 🛠️ Developer Documentation
+### 🛠️ Developer & Contributor Docs
 
 **For Contributors:**
-- 🔧 **[Development Docs](development/docs/)** - Internal documentation index
-- 💻 [Development Setup](development/docs/DEVELOPMENT.md) - Local environment
+- 💻 [Development Setup](development/docs/DEVELOPMENT.md) - Local environment setup
 - 🐳 [Docker Services](development/docs/DOCKER.md) - PostgreSQL, Redis, MinIO
+- 🔧 [Development Docs](development/docs/) - Internal documentation
 
 **Deployment & Infrastructure:**
-- 🚀 [Deployment Summary](development/docs/DEPLOYMENT_SUMMARY.md) - Complete deployment guide
-- 📊 [Deployment Quickstart](development/docs/DEPLOYMENT_QUICKSTART.md) - TL;DR deployment
+- 🚀 [Deployment Guide](development/docs/DEPLOYMENT_SUMMARY.md) - Complete deployment guide
+- 📊 [Deployment Quickstart](development/docs/DEPLOYMENT_QUICKSTART.md) - Quick deployment
 - 🔄 [CI/CD Workflows](development/docs/GITHUB_WORKFLOWS.md) - GitHub Actions
 
 ### 🔥 Karen Code Reviews
-- 🔥 [Get Your Karen Score](GET_KAREN_SCORE.md)
-- 📖 [Karen GitHub Action](https://github.com/pr-pm/karen-action)
-- 💡 [Karen Implementation](KAREN_IMPLEMENTATION.md)
+- 🔥 [Get Your Karen Score](GET_KAREN_SCORE.md) - Brutally honest AI code reviews
+- 📖 [Karen GitHub Action](https://github.com/pr-pm/karen-action) - Automate reviews in CI
+- 💡 [Karen Implementation](KAREN_IMPLEMENTATION.md) - Technical details
 
 ---
 
@@ -413,7 +403,7 @@ MIT License - See [LICENSE](LICENSE)
 
 **Stop copy-pasting. Start installing.**
 
-**[Install PRPM](#installation)** | **[Browse Collections](https://prpm.dev/search?tab=collections)** | **[Get Karen Score](GET_KAREN_SCORE.md)**
+**[Read the Docs](https://docs.prpm.dev)** | **[Install PRPM](#installation)** | **[Browse Packages](https://prpm.dev)** | **[Get Karen Score](GET_KAREN_SCORE.md)**
 
 _Collections install multiple curated packages with one command • Packages work in all editors • No manual copying needed_
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,25 @@
-# PRPM User Documentation
+# PRPM Documentation
 
-Documentation for using the Prompt Package Manager (PRPM).
+> **📚 For the most up-to-date documentation, visit [docs.prpm.dev](https://docs.prpm.dev)**
 
-## Quick Links
+This directory contains legacy documentation files. We recommend using the official documentation site for the best experience.
 
-📦 **[Main README](../README.md)** - Project overview and quick start
-🚀 **[Installation Guide](./INSTALLATION.md)** - Get started with PRPM
-💻 **[CLI Reference](./CLI.md)** - Complete command reference
-⚙️ **[Configuration](./CONFIGURATION.md)** - Configure PRPM for your workflow
+## 🌐 Official Documentation
+
+**➡️ [docs.prpm.dev](https://docs.prpm.dev)** - Complete, searchable documentation
+
+**Quick Links:**
+- 🚀 [Getting Started](https://docs.prpm.dev/getting-started/installation) - Install and configure PRPM
+- 💻 [CLI Reference](https://docs.prpm.dev/cli/commands) - All commands and options
+- 📦 [Collections Guide](https://docs.prpm.dev/concepts/collections) - Multi-package bundles
+- 🎯 [Usage Examples](https://docs.prpm.dev/guides/usage-examples) - Real-world workflows
+- 📝 [Publishing Guide](https://docs.prpm.dev/publishing/overview) - Publish your packages
+
+---
+
+## Legacy Local Documentation
+
+These files are maintained for reference but may be outdated. **Use [docs.prpm.dev](https://docs.prpm.dev) for current information.**
 
 ---
 


### PR DESCRIPTION
## Summary

Updates repository README and documentation to prominently direct users to the official documentation site at **[docs.prpm.dev](https://docs.prpm.dev)**.

## Why This Change?

The official documentation site provides:
- ✅ Better search and navigation
- ✅ Professional documentation experience  
- ✅ Easier to keep current and comprehensive
- ✅ Single source of truth
- ✅ Reduced maintenance on repo docs

## Changes

### Main README.md

**Top of File:**
- Added prominent link to docs.prpm.dev right below the tagline
- Links to both docs and package browsing

**Throughout File:**
All documentation references now point to docs.prpm.dev:
- CLI Reference → `https://docs.prpm.dev/cli/commands`
- Installation Guide → `https://docs.prpm.dev/getting-started/installation`
- Configuration Guide → `https://docs.prpm.dev/getting-started/configuration`
- Usage Examples → `https://docs.prpm.dev/guides/usage-examples`
- Format Conversion → `https://docs.prpm.dev/concepts/format-conversion`
- Collections Guide → `https://docs.prpm.dev/concepts/collections`
- MCP Servers → `https://docs.prpm.dev/guides/mcp-servers`

**Documentation Section:**
- Completely restructured to highlight official docs first
- Prominent **"➡️ docs.prpm.dev - Complete documentation"** callout
- Quick links to key documentation sections
- Developer docs section remains pointing to local development files
- Karen docs section updated

**Footer:**
- Added "Read the Docs" as first link

### docs/README.md

**Clear Notice:**
- Large callout directing users to docs.prpm.dev
- Explains local docs are legacy/reference

**Official Documentation Section:**
- Direct link to docs.prpm.dev
- Quick links to major documentation sections
- All links point to official site

**Legacy Label:**
- Clearly marks local documentation as legacy
- Maintains index for reference purposes
- Recommends official docs for current info

## Before vs After

**Before:**
```markdown
**[Full CLI Reference →](docs/CLI.md)**
```

**After:**
```markdown
📚 **[Full CLI Reference](https://docs.prpm.dev/cli/commands)** | **[All Documentation](https://docs.prpm.dev)**
```

## User Experience

Users will now:
1. See docs.prpm.dev immediately at the top of README
2. Find better, searchable documentation
3. Have access to always-current information
4. Experience professional docs site instead of raw markdown

## Backward Compatibility

- ✅ Local documentation files remain intact
- ✅ Existing links won't break (files still exist)
- ✅ Clear guidance to use official docs instead
- ✅ Developer/contributor docs unchanged

## Testing

- [x] All links verified and working
- [x] docs.prpm.dev accessible and comprehensive
- [x] Local docs still readable as fallback
- [x] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>