### PR TITLE
fix: honor telemetryEnabled config from .prpmrc

### DIFF
--- a/packages/cli/src/commands/telemetry.ts
+++ b/packages/cli/src/commands/telemetry.ts
@@ -15,7 +15,7 @@ function createStatusCommand() {
   return new Command('status')
     .description('Show current telemetry status')
     .action(async () => {
-      const enabled = telemetry.isEnabled();
+      const enabled = await telemetry.isEnabled();
       const stats = await telemetry.getStats();
 
       console.log('📊 Telemetry Status:');

--- a/packages/cli/src/core/telemetry.ts
+++ b/packages/cli/src/core/telemetry.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
 import { PostHog } from 'posthog-node';
+import { getConfig } from './user-config';
 
 export interface TelemetryEvent {
   timestamp: string;
@@ -29,14 +30,38 @@ class Telemetry {
   private events: TelemetryEvent[] = [];
   private readonly maxEvents = 100; // Keep only last 100 events locally
   private posthog: PostHog | null = null;
+  private userConfigChecked = false;
+  private userTelemetryEnabled = true; // Default to true until checked
 
   constructor() {
     this.configPath = path.join(os.homedir(), '.prpm', 'telemetry.json');
     this.config = this.loadConfig();
-    this.initializePostHog();
   }
 
-  private initializePostHog(): void {
+  private async checkUserConfig(): Promise<void> {
+    if (this.userConfigChecked) return;
+
+    try {
+      const userConfig = await getConfig();
+      this.userTelemetryEnabled = userConfig.telemetryEnabled ?? true;
+    } catch (error) {
+      // If we can't load user config, default to enabled
+      this.userTelemetryEnabled = true;
+    }
+
+    this.userConfigChecked = true;
+  }
+
+  private async initializePostHog(): Promise<void> {
+    // Check user config first
+    await this.checkUserConfig();
+
+    // Only initialize if telemetry is enabled in user config
+    if (!this.userTelemetryEnabled) {
+      this.posthog = null;
+      return;
+    }
+
     try {
       this.posthog = new PostHog('phc_aO5lXLILeylHfb1ynszVwKbQKSzO91UGdXNhN5Q0Snl', {
         host: 'https://app.posthog.com',
@@ -79,6 +104,12 @@ class Telemetry {
   }
 
   async track(event: Omit<TelemetryEvent, 'timestamp' | 'version' | 'platform' | 'arch' | 'nodeVersion'>): Promise<void> {
+    // Check user config first
+    await this.checkUserConfig();
+
+    // Return early if telemetry is disabled in user config
+    if (!this.userTelemetryEnabled) return;
+
     if (!this.config.enabled) return;
 
     const fullEvent: TelemetryEvent = {
@@ -117,6 +148,11 @@ class Telemetry {
   }
 
   private async sendToAnalytics(event: TelemetryEvent): Promise<void> {
+    // Initialize PostHog if needed (this will check user config)
+    if (!this.posthog && this.userTelemetryEnabled) {
+      await this.initializePostHog();
+    }
+
     // Send to PostHog
     await this.sendToPostHog(event);
   }
@@ -131,8 +167,9 @@ class Telemetry {
     await this.saveConfig();
   }
 
-  isEnabled(): boolean {
-    return this.config.enabled;
+  async isEnabled(): Promise<boolean> {
+    await this.checkUserConfig();
+    return this.userTelemetryEnabled && this.config.enabled;
   }
 
   async getStats(): Promise<{ totalEvents: number; lastEvent?: string }> {


### PR DESCRIPTION
## Summary
Fixes #105 - The `telemetryEnabled` config setting is now properly honored, preventing PostHog initialization and network calls when telemetry is disabled.

## Changes
- Import and check user config (`telemetryEnabled` from `.prpmrc`) in telemetry system
- Initialize PostHog only when telemetry is enabled in user config
- Add early return in `track()` method when telemetry is disabled
- Update `isEnabled()` to check both user config and telemetry config (now async)
- Update telemetry status command to await `isEnabled()`

## Problem Solved
Previously, the telemetry system would always try to initialize PostHog regardless of the `telemetryEnabled` setting in `.prpmrc`. This caused:
- 5-second timeouts on commands like `prpm install` and `prpm list`
- Network errors when PostHog endpoints were blocked by DNS filters
- Poor user experience when telemetry was explicitly disabled

## Technical Details
The fix introduces a lazy-loading pattern where:
1. User config is checked the first time telemetry is needed
2. PostHog is only initialized if `telemetryEnabled` is `true`
3. All telemetry operations short-circuit early when disabled

This prevents any network calls to PostHog when telemetry is disabled, eliminating the timeout issue.

## Test Plan
- [x] Verify code changes respect `telemetryEnabled` config
- [ ] Manual test: Set `telemetryEnabled: false` in `.prpmrc` and run `prpm install` - should complete quickly with no PostHog connection attempts
- [ ] Manual test: Set `telemetryEnabled: true` and verify telemetry still works
- [ ] Manual test: Run `prpm telemetry status` with both enabled/disabled states

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)