### PR TITLE
docs: Add Git workflow rules to prpm-development skill

### DIFF
--- a/.claude/skills/prpm-development/SKILL.md
+++ b/.claude/skills/prpm-development/SKILL.md
@@ -33,6 +33,57 @@ Build the npm/cargo/pip equivalent for AI development artifacts. Enable develope
 - **Telemetry Opt-Out**: Privacy-first with easy opt-out
 - **Beautiful CLI**: Clear progress indicators and colored output
 
+### Git Workflow - CRITICAL RULES
+
+**⚠️ NEVER PUSH DIRECTLY TO MAIN ⚠️**
+
+PRPM uses a **branch-based workflow** with CI/CD automation. Direct pushes to main bypass all safety checks and can break production.
+
+**ALWAYS follow this workflow:**
+
+1. **Create a branch** for your changes:
+   ```bash
+   git checkout -b feature/your-feature-name
+   # or
+   git checkout -b fix/bug-description
+   ```
+
+2. **Make commits** on your branch:
+   ```bash
+   git add [files]
+   git commit -m "feat: description"
+   ```
+
+3. **Push your branch**:
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+
+4. **Create a Pull Request** on GitHub:
+   - Automated CI tests run
+   - Code review happens
+   - Deployments are controlled
+
+5. **After PR approval**, merge through GitHub UI:
+   - Triggers automated deployment
+   - Ensures CI passes first
+   - Maintains deployment history
+
+**Why this matters:**
+- Main branch is protected and deploys to production
+- Direct pushes skip CI tests, linting, type checks
+- Can deploy broken code to 7500+ package registry
+- Breaks audit trail and rollback capability
+- GitHub Actions workflows expect PRs, not direct pushes
+
+**If you accidentally pushed to main:**
+1. **DO NOT** force push to revert - breaks CI/CD
+2. Create a revert commit on a branch
+3. Open PR to fix the issue properly
+4. Let CI/CD handle the corrective deployment
+
+**Exception:** Only repository admins can push to main for emergency hotfixes (with explicit approval).
+
 ## Package Types
 
 ### 🎓 Skill


### PR DESCRIPTION
## Summary
Adds critical Git workflow documentation to the `prpm-development` skill to prevent direct pushes to main branch.

## Changes
- ✅ New "Git Workflow - CRITICAL RULES" section in prpm-development skill
- ✅ Prominent warning: **NEVER PUSH DIRECTLY TO MAIN**
- ✅ Step-by-step branch-based workflow guide
- ✅ Explanation of why direct pushes are dangerous
- ✅ Recovery instructions if accidental push happens
- ✅ Emergency hotfix exception policy

## Why This Matters
Direct pushes to main:
- Bypass CI/CD automation and all safety checks
- Skip automated tests, linting, and type checking
- Can deploy broken code to production registry
- Break audit trail and rollback capability
- Cause deployment issues (like we just experienced)

## Impact
Future Claude Code sessions will read this skill and follow the proper workflow:
1. Create feature branch
2. Make commits
3. Push branch
4. Open PR (with CI checks)
5. Merge after approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)