### PR TITLE
fix: Align navigation links in blog post header

### DIFF
--- a/packages/webapp/src/app/blog/format-specifications-guide/page.tsx
+++ b/packages/webapp/src/app/blog/format-specifications-guide/page.tsx
@@ -26,13 +26,13 @@ export default function FormatSpecificationsGuidePage() {
                 </span>
               </Link>
               <div className="hidden md:flex items-center gap-6">
-                <Link href="/search" className="text-gray-400 hover:text-white transition-colors">
+                <Link href="/search" className="text-gray-400 hover:text-white transition-colors flex items-center">
                   Search
                 </Link>
-                <Link href="/authors" className="text-gray-400 hover:text-white transition-colors">
+                <Link href="/authors" className="text-gray-400 hover:text-white transition-colors flex items-center">
                   Authors
                 </Link>
-                <Link href="/blog" className="text-gray-400 hover:text-white transition-colors">
+                <Link href="/blog" className="text-gray-400 hover:text-white transition-colors flex items-center">
                   Blog
                 </Link>
               </div>


### PR DESCRIPTION
## Summary

Fixes header navigation misalignment in blog post pages.

## Problem

The navigation links (Search, Authors, Blog) in the blog post header were not properly vertically aligned with the PRPM logo, creating a visual inconsistency.

## Solution

Added `flex items-center` classes to each navigation link to ensure proper vertical centering, matching the styling pattern used in the shared `Header` component.

## Changes

- Updated navigation link classes in `packages/webapp/src/app/blog/format-specifications-guide/page.tsx`
- Applied consistent flex alignment for all three navigation links

## Visual Impact

✅ Navigation links now properly align vertically with the logo
✅ Consistent with the shared Header component styling

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)