### PR TITLE
fix mcp install for codex

### DIFF
--- a/packages/cli/src/__tests__/install-file-locations.test.ts
+++ b/packages/cli/src/__tests__/install-file-locations.test.ts
@@ -944,6 +944,62 @@ Follow TypeScript best practices.
       expect(mcpConfig.mcpServers['test-server'].command).toBe('npx');
     });
 
+    it('installs MCP server to .codex/config.toml when --as codex is used (as + editor)', async () => {
+      // This tests the real CLI path: --as codex sets both as: 'codex' and editor: 'codex'
+      const mockPackage = {
+        id: '@test/mcp-as-codex',
+        name: '@test/mcp-as-codex',
+        format: 'mcp',
+        subtype: 'server',
+        tags: ['mcp'],
+        total_downloads: 5,
+        verified: false,
+        latest_version: {
+          version: '1.0.0',
+          tarball_url: 'https://example.com/package.tar.gz',
+        },
+      };
+
+      mockClient.getPackage.mockResolvedValue(mockPackage);
+      mockClient.downloadPackage.mockResolvedValue(await createMCPTarball(mcpServerJson));
+
+      // The CLI passes both as and editor when --as codex is used
+      await handleInstall('@test/mcp-as-codex', { as: 'codex', editor: 'codex' });
+
+      // Should write to .codex/config.toml, NOT to AGENTS.md
+      const codexConfig = await fs.readFile(path.join(testDir, '.codex', 'config.toml'), 'utf-8');
+      expect(codexConfig).toContain('[mcp_servers.test-server]');
+      expect(codexConfig).toContain('command = "npx"');
+
+      // Should NOT have saved any AGENTS.md content
+      expect(saveFile).not.toHaveBeenCalledWith(expect.stringContaining('AGENTS.md'), expect.any(String));
+    });
+
+    it('installs MCP tool to .cursor/mcp.json when --as cursor is used (as + editor)', async () => {
+      const mockPackage = {
+        id: '@test/mcp-as-cursor',
+        name: '@test/mcp-as-cursor',
+        format: 'mcp',
+        subtype: 'tool',
+        tags: ['mcp'],
+        total_downloads: 5,
+        verified: false,
+        latest_version: {
+          version: '1.0.0',
+          tarball_url: 'https://example.com/package.tar.gz',
+        },
+      };
+
+      mockClient.getPackage.mockResolvedValue(mockPackage);
+      mockClient.downloadPackage.mockResolvedValue(await createMCPTarball(mcpServerJson));
+
+      await handleInstall('@test/mcp-as-cursor', { as: 'cursor', editor: 'cursor' });
+
+      const cursorConfig = JSON.parse(await fs.readFile(path.join(testDir, '.cursor', 'mcp.json'), 'utf-8'));
+      expect(cursorConfig.mcpServers['test-server']).toBeDefined();
+      expect(cursorConfig.mcpServers['test-server'].command).toBe('npx');
+    });
+
     it('preserves MCP format even when auto-detection would pick agents.md', async () => {
       // Create .agents.md directory to trigger auto-detection
       await fs.mkdir(path.join(testDir, '.agents.md'), { recursive: true });

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -667,7 +667,9 @@ export async function handleInstall(
 
     // Client-side format conversion (if --as flag is specified)
     // Skip conversion for snippets - they're raw content that doesn't need format conversion
-    if (options.as && format && format !== pkg.format && effectiveSubtype !== 'snippet') {
+    // Skip conversion for MCP server packages targeting an MCP editor — they use the dedicated MCP install path
+    const isMCPToEditor = isMCPServerPackage && MCP_EDITORS.includes(format as MCPEditor);
+    if (options.as && format && format !== pkg.format && effectiveSubtype !== 'snippet' && !isMCPToEditor) {
       console.log(`   🔄 Converting from ${pkg.format} to ${format}...`);
 
       // Find the main file to convert
@@ -999,8 +1001,10 @@ export async function handleInstall(
       destPath = '.claude/';
       fileCount = installedFiles.length;
     }
-    // Special handling for MCP server packages (install server configs to .mcp.json)
-    else if (effectiveFormat === 'mcp' && (effectiveSubtype === 'server' || effectiveSubtype === 'tool')) {
+    // Special handling for MCP server packages (install server configs to .mcp.json or editor config)
+    // Match when: native MCP format, OR source is MCP and --as targets an MCP editor (e.g., --as codex)
+    else if ((effectiveFormat === 'mcp' && (effectiveSubtype === 'server' || effectiveSubtype === 'tool')) ||
+             (isMCPServerPackage && (pkg.subtype === 'server' || pkg.subtype === 'tool') && isMCPToEditor)) {
       console.log(`   🔧 Installing MCP Server...`);
 
       // Find and parse the MCP server config file


### PR DESCRIPTION
## **CodeAnt-AI Description**
Install MCP servers/tools into editor-specific configs when using --as (codex/cursor)

### What Changed
- When users run install with --as codex, MCP server packages are written to .codex/config.toml (and not to AGENTS.md); when run with --as cursor, MCP tools are written to .cursor/mcp.json
- Conversion step is skipped for MCP server packages that are being installed into an MCP editor via --as, so the original MCP config is preserved and installed to the editor's config
- Added tests that verify .codex/config.toml and .cursor/mcp.json receive the MCP entries and that AGENTS.md is not written in the codex case

### Impact
`✅ MCP installs land in Codex config instead of AGENTS.md`
`✅ MCP tools install into Cursor's mcp.json`
`✅ Fewer incorrect format conversions when installing MCP into editors`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
