### PR TITLE
fix: codex MCP env vars use --env args instead of nested TOML section

### DIFF
--- a/packages/cli/src/core/__tests__/mcp.test.ts
+++ b/packages/cli/src/core/__tests__/mcp.test.ts
@@ -317,6 +317,73 @@ describe('MCP utilities', () => {
       // Verify TOML format
       expect(content).toContain('[mcp_servers.test-server]');
       expect(content).toContain('command = "npx"');
+      // Env vars should be passed as --env KEY=VALUE args, not as nested [env] section
+      expect(content).toContain('--env');
+      expect(content).toContain('API_KEY=test-key');
+      expect(content).not.toContain('[mcp_servers.test-server.env]');
+    });
+
+    it('passes env vars as --env KEY=VALUE args appended to args array', async () => {
+      const servers: Record<string, MCPServer> = {
+        'relaycast': {
+          command: 'npx',
+          args: ['-y', '@relaycast/mcp'],
+          env: { RELAY_BASE_URL: 'https://api.relaycast.dev' },
+        },
+      };
+
+      const result = mergeCodexMCPServers(servers, false, tempDir);
+      expect(result.added).toContain('relaycast');
+
+      const configPath = join(tempDir, '.codex', 'config.toml');
+      const content = await readFile(configPath, 'utf-8');
+
+      // Should have args with --env appended
+      expect(content).toContain('[mcp_servers.relaycast]');
+      expect(content).toContain('command = "npx"');
+      expect(content).toContain('"--env"');
+      expect(content).toContain('"RELAY_BASE_URL=https://api.relaycast.dev"');
+      // Must NOT have a nested env section
+      expect(content).not.toContain('[mcp_servers.relaycast.env]');
+    });
+
+    it('handles multiple env vars as multiple --env args', async () => {
+      const servers: Record<string, MCPServer> = {
+        'multi-env': {
+          command: 'node',
+          args: ['server.js'],
+          env: { API_KEY: 'key123', DB_URL: 'postgres://localhost' },
+        },
+      };
+
+      const result = mergeCodexMCPServers(servers, false, tempDir);
+      expect(result.added).toContain('multi-env');
+
+      const configPath = join(tempDir, '.codex', 'config.toml');
+      const content = await readFile(configPath, 'utf-8');
+
+      expect(content).toContain('"API_KEY=key123"');
+      expect(content).toContain('"DB_URL=postgres://localhost"');
+      expect(content).not.toContain('[mcp_servers.multi-env.env]');
+    });
+
+    it('handles env vars when args array is empty', async () => {
+      const servers: Record<string, MCPServer> = {
+        'env-only': {
+          command: 'my-server',
+          env: { TOKEN: 'abc' },
+        },
+      };
+
+      const result = mergeCodexMCPServers(servers, false, tempDir);
+      expect(result.added).toContain('env-only');
+
+      const configPath = join(tempDir, '.codex', 'config.toml');
+      const content = await readFile(configPath, 'utf-8');
+
+      expect(content).toContain('"--env"');
+      expect(content).toContain('"TOKEN=abc"');
+      expect(content).not.toContain('[mcp_servers.env-only.env]');
     });
 
     it('handles HTTP servers', async () => {

--- a/packages/cli/src/core/mcp.ts
+++ b/packages/cli/src/core/mcp.ts
@@ -489,14 +489,18 @@ function toCodexServerConfig(server: MCPServer): Record<string, unknown> {
   // Handle stdio servers (command-based)
   if (server.command) {
     codexServer.command = server.command;
-    if (server.args && server.args.length > 0) {
-      codexServer.args = server.args;
+    // Codex expects env vars as --env KEY=VALUE args, not as a nested env object
+    const envArgs: string[] = [];
+    if (server.env && Object.keys(server.env).length > 0) {
+      for (const [key, value] of Object.entries(server.env)) {
+        envArgs.push('--env', `${key}=${value}`);
+      }
+    }
+    if (server.args && server.args.length > 0 || envArgs.length > 0) {
+      codexServer.args = [...(server.args || []), ...envArgs];
     }
     if (server.cwd) {
       codexServer.cwd = server.cwd;
-    }
-    if (server.env && Object.keys(server.env).length > 0) {
-      codexServer.env = server.env;
     }
   }
 


### PR DESCRIPTION
## **User description**
## Summary

- Codex expects env vars as `--env KEY=VALUE` args appended to the args array, not as a nested `[mcp_servers.name.env]` TOML section
- Updated `toCodexServerConfig` in `mcp.ts` to convert `env` entries into `--env KEY=VALUE` args
- Before: `[mcp_servers.relaycast.env]` with `RELAY_BASE_URL = "https://api.relaycast.dev"` 
- After: `args = ["-y", "@relaycast/mcp", "--env", "RELAY_BASE_URL=https://api.relaycast.dev"]`

## Test plan

- [x] Updated existing test to verify no `[env]` section in TOML output
- [x] Added test for single env var as `--env` arg
- [x] Added test for multiple env vars as multiple `--env` args
- [x] Added test for env vars when args array is empty
- [x] All 121 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Pass MCP server environment variables to Codex as --env args, not a nested TOML env section

### What Changed
- When a server defines env vars, they are converted into "--env KEY=VALUE" entries appended to the server's args array in the generated Codex config instead of creating a nested [mcp_servers.<name>.env] TOML section
- Supports combining existing args with env-derived --env entries and handles cases where args are empty (args created solely from env vars)
- Added tests verifying single env var, multiple env vars, and env-only scenarios and asserting no nested env section appears in the TOML output

### Impact
`✅ Correct env propagation to Codex MCP servers`
`✅ Fewer Codex config parsing errors due to unexpected nested env sections`
`✅ More predictable MCP startup when environment variables are required`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
