### PR TITLE
fix update logic

### DIFF
--- a/packages/cli/src/__tests__/update.test.ts
+++ b/packages/cli/src/__tests__/update.test.ts
@@ -1,0 +1,244 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+type Mock = ReturnType<typeof vi.fn>;
+
+/**
+ * Tests for update command - format preservation
+ */
+
+import { handleUpdate } from '../commands/update';
+import { getRegistryClient } from '@pr-pm/registry-client';
+import { getConfig } from '../core/user-config';
+import {
+  listPackages,
+  parseLockfileKey,
+} from '../core/lockfile';
+import { handleInstall } from '../commands/install';
+
+// Mock dependencies
+vi.mock('@pr-pm/registry-client');
+vi.mock('../core/user-config');
+vi.mock('../commands/install');
+vi.mock('../core/lockfile', () => ({
+  listPackages: vi.fn(),
+  readLockfile: vi.fn(),
+  writeLockfile: vi.fn(),
+  parseLockfileKey: vi.fn((key: string) => {
+    const parts = key.split('#');
+    return { packageId: parts[0], format: parts[1] };
+  }),
+}));
+vi.mock('../core/telemetry', () => ({
+  telemetry: {
+    track: vi.fn(),
+    shutdown: vi.fn(),
+  },
+}));
+
+describe('update command', () => {
+  const mockClient = {
+    getPackage: vi.fn(),
+  };
+
+  const mockConfig = {
+    registryUrl: 'https://test-registry.com',
+    token: 'test-token',
+  };
+
+  beforeEach(() => {
+    (getRegistryClient as Mock).mockReturnValue(mockClient);
+    (getConfig as Mock).mockResolvedValue(mockConfig);
+    (handleInstall as Mock).mockResolvedValue(undefined);
+
+    vi.spyOn(console, 'log').mockImplementation();
+    vi.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  describe('format preservation', () => {
+    it('should always pass format to handleInstall to prevent auto-detection', async () => {
+      // Bug: when format === sourceFormat, the old code skipped passing `as`,
+      // causing auto-detection which installed to .openskills/ instead of the correct location
+      (listPackages as Mock).mockResolvedValue([
+        {
+          id: '@agent-relay/writing-agent-relay-workflows#claude',
+          version: '1.0.2',
+          format: 'claude',
+          sourceFormat: 'claude', // Same as format - this was the bug trigger
+          installedPath: '.claude/skills/writing-agent-relay-workflows/SKILL.md',
+        },
+      ]);
+
+      mockClient.getPackage.mockResolvedValue({
+        id: '@agent-relay/writing-agent-relay-workflows',
+        latest_version: { version: '1.0.6' },
+      });
+
+      await handleUpdate();
+
+      expect(handleInstall).toHaveBeenCalledWith(
+        '@agent-relay/writing-agent-relay-workflows@1.0.6',
+        { as: 'claude' }
+      );
+    });
+
+    it('should preserve codex format when updating a converted package', async () => {
+      (listPackages as Mock).mockResolvedValue([
+        {
+          id: '@agent-relay/writing-agent-relay-workflows#codex',
+          version: '1.0.2',
+          format: 'codex',
+          sourceFormat: 'claude',
+          installedPath: '.agents/skills/writing-agent-relay-workflows/SKILL.md',
+        },
+      ]);
+
+      mockClient.getPackage.mockResolvedValue({
+        id: '@agent-relay/writing-agent-relay-workflows',
+        latest_version: { version: '1.0.6' },
+      });
+
+      await handleUpdate();
+
+      expect(handleInstall).toHaveBeenCalledWith(
+        '@agent-relay/writing-agent-relay-workflows@1.0.6',
+        { as: 'codex' }
+      );
+    });
+
+    it('should fall back to key format for older lockfiles without pkg.format', async () => {
+      (listPackages as Mock).mockResolvedValue([
+        {
+          id: '@scope/my-skill#cursor',
+          version: '1.0.0',
+          // format is undefined (older lockfile)
+          sourceFormat: 'claude',
+        },
+      ]);
+
+      mockClient.getPackage.mockResolvedValue({
+        id: '@scope/my-skill',
+        latest_version: { version: '1.0.1' },
+      });
+
+      await handleUpdate();
+
+      expect(handleInstall).toHaveBeenCalledWith(
+        '@scope/my-skill@1.0.1',
+        { as: 'cursor' }
+      );
+    });
+
+    it('should handle packages without any format (allow auto-detect)', async () => {
+      (listPackages as Mock).mockResolvedValue([
+        {
+          id: 'some-package',
+          version: '1.0.0',
+        },
+      ]);
+
+      (parseLockfileKey as Mock).mockReturnValue({
+        packageId: 'some-package',
+        format: undefined,
+      });
+
+      mockClient.getPackage.mockResolvedValue({
+        id: 'some-package',
+        latest_version: { version: '1.0.1' },
+      });
+
+      await handleUpdate();
+
+      expect(handleInstall).toHaveBeenCalledWith(
+        'some-package@1.0.1',
+        { as: undefined }
+      );
+    });
+  });
+
+  describe('version filtering', () => {
+    it('should skip major version updates', async () => {
+      (listPackages as Mock).mockResolvedValue([
+        {
+          id: 'pkg#claude',
+          version: '1.0.0',
+          format: 'claude',
+        },
+      ]);
+
+      mockClient.getPackage.mockResolvedValue({
+        id: 'pkg',
+        latest_version: { version: '2.0.0' },
+      });
+
+      await handleUpdate();
+
+      expect(handleInstall).not.toHaveBeenCalled();
+    });
+
+    it('should update minor versions', async () => {
+      (listPackages as Mock).mockResolvedValue([
+        {
+          id: 'pkg#claude',
+          version: '1.0.0',
+          format: 'claude',
+        },
+      ]);
+
+      mockClient.getPackage.mockResolvedValue({
+        id: 'pkg',
+        latest_version: { version: '1.1.0' },
+      });
+
+      await handleUpdate();
+
+      expect(handleInstall).toHaveBeenCalledWith(
+        'pkg@1.1.0',
+        { as: 'claude' }
+      );
+    });
+
+    it('should skip packages already at latest version', async () => {
+      (listPackages as Mock).mockResolvedValue([
+        {
+          id: 'pkg#claude',
+          version: '1.1.0',
+          format: 'claude',
+        },
+      ]);
+
+      mockClient.getPackage.mockResolvedValue({
+        id: 'pkg',
+        latest_version: { version: '1.1.0' },
+      });
+
+      await handleUpdate();
+
+      expect(handleInstall).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error handling', () => {
+    it('should continue updating other packages when one fails', async () => {
+      (listPackages as Mock).mockResolvedValue([
+        { id: 'pkg1#claude', version: '1.0.0', format: 'claude' },
+        { id: 'pkg2#claude', version: '1.0.0', format: 'claude' },
+      ]);
+
+      mockClient.getPackage
+        .mockResolvedValueOnce({ id: 'pkg1', latest_version: { version: '1.1.0' } })
+        .mockResolvedValueOnce({ id: 'pkg2', latest_version: { version: '1.1.0' } });
+
+      (handleInstall as Mock)
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce(undefined);
+
+      await handleUpdate();
+
+      expect(handleInstall).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -85,12 +85,12 @@ export async function handleUpdate(
           `\n📦 Updating ${packageId}: ${currentVersion} → ${latestVersion}`,
         );
 
-        // Install new version, preserving the installed format if it was converted
-        const installOptions: { as?: string } = {};
-        if (installedFormat && installedFormat !== pkg.sourceFormat) {
-          installOptions.as = installedFormat;
-        }
-        await handleInstall(`${packageId}@${latestVersion}`, installOptions);
+        // Always pass the installed format to prevent auto-detection
+        // Use pkg.format (entry data) with installedFormat (from key suffix) as fallback
+        const targetFormat = pkg.format || installedFormat;
+        await handleInstall(`${packageId}@${latestVersion}`, {
+          as: targetFormat,
+        });
 
         updatedCount++;
       } catch (err) {


### PR DESCRIPTION
## **CodeAnt-AI Description**
**Keep package updates in the same install format**

### What Changed
- Updates now keep the package’s existing format when reinstalling, so converted packages stay in the same location instead of being auto-detected differently.
- Older lockfiles still update correctly by falling back to the format stored in the package key when the newer format field is missing.
- Added coverage for format preservation, skipping major version updates, and continuing when one package update fails.

### Impact
`✅ Packages stay in the expected folder after update`
`✅ Fewer broken updates for converted packages`
`✅ Safer bulk updates with one failure not stopping the rest`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
