### PR TITLE
Fix multi-file packages dropping supporting files on format conversion

### DIFF
--- a/packages/cli/src/__tests__/install-multifile.test.ts
+++ b/packages/cli/src/__tests__/install-multifile.test.ts
@@ -212,6 +212,53 @@ describe('install command - multi-file packages', () => {
       );
     });
 
+    it('should preserve supporting files when converting a multi-file skill to codex (--as codex)', async () => {
+      // Regression: converting a multi-file package used to collapse extractedFiles
+      // down to the converted main file, dropping references/, helpers/, etc.
+      const mockPackage = {
+        id: 'complex-skill',
+        name: 'complex-skill',
+        format: 'claude', subtype: 'skill',
+        tags: [],
+        total_downloads: 100,
+        verified: true,
+        latest_version: {
+          version: '1.0.0',
+          tarball_url: 'https://example.com/package.tar.gz',
+        },
+      };
+
+      const tarGz = await createTarGz({
+        'SKILL.md': '---\nname: complex-skill\ndescription: A complex skill\n---\n\n# Main Skill File\n\nBody content here.',
+        'helpers/utils.md': '# Utility Functions',
+        'references/guide.md': '# Reference Guide',
+      }, { format: 'claude', subtype: 'skill', packageName: 'complex-skill' });
+
+      mockClient.getPackage.mockResolvedValue(mockPackage);
+      mockClient.downloadPackage.mockResolvedValue(tarGz);
+
+      await handleInstall('complex-skill', { as: 'codex' });
+
+      // All three files must land in the codex skill directory
+      expect(saveFile).toHaveBeenCalledTimes(3);
+
+      // Main file is converted (content regenerated) but still written as SKILL.md
+      expect(saveFile).toHaveBeenCalledWith(
+        '.agents/skills/complex-skill/SKILL.md',
+        expect.stringContaining('Body content here.')
+      );
+
+      // Supporting files are copied verbatim, preserving subdirectories
+      expect(saveFile).toHaveBeenCalledWith(
+        '.agents/skills/complex-skill/helpers/utils.md',
+        '# Utility Functions'
+      );
+      expect(saveFile).toHaveBeenCalledWith(
+        '.agents/skills/complex-skill/references/guide.md',
+        '# Reference Guide'
+      );
+    });
+
     it('should reject tampered tarballs with corrupted headers (security)', async () => {
       // Security: tampered archives should be rejected with strict mode enabled
       const mockPackage = {
@@ -394,12 +441,17 @@ describe('install command - multi-file packages', () => {
       // Should succeed and convert only the main file (SKILL.md)
       await handleInstall('complex-skill', { as: 'cursor' });
 
-      // Cursor doesn't have native skill support - uses progressive disclosure
-      // Should save to .openskills/ with AGENTS.md reference
-      expect(saveFile).toHaveBeenCalledTimes(1);
+      // Cursor doesn't have native skill support - uses progressive disclosure.
+      // The main file is converted and kept as SKILL.md; supporting files are
+      // preserved verbatim alongside it (not dropped).
+      expect(saveFile).toHaveBeenCalledTimes(2);
       expect(saveFile).toHaveBeenCalledWith(
         '.openskills/complex-skill/SKILL.md',
         expect.stringContaining('Main Skill')
+      );
+      expect(saveFile).toHaveBeenCalledWith(
+        '.openskills/complex-skill/helper.md',
+        '# Helper'
       );
     });
 

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -719,6 +719,10 @@ export async function handleInstall(
       // For single-file packages, use the only file
       // For multi-file packages, find the main file based on format/subtype conventions
       let sourceContent: string;
+      // Index of the main entry point within extractedFiles. Only this file is
+      // format-converted; for multi-file packages the remaining (supporting)
+      // files are copied verbatim so the full directory tree is preserved.
+      let mainFileIndex = 0;
 
       if (extractedFiles.length === 1) {
         sourceContent = extractedFiles[0].content;
@@ -731,6 +735,7 @@ export async function handleInstall(
             `Expected files like SKILL.md, agent.md, or similar main entry points.`
           );
         }
+        mainFileIndex = extractedFiles.indexOf(mainFile);
         console.log(`   📄 Using main file: ${mainFile.name}`);
         sourceContent = mainFile.content;
       }
@@ -902,11 +907,25 @@ export async function handleInstall(
         throw new CLIError('Conversion failed: No content generated');
       }
 
-      // Replace extracted content with converted content
-      extractedFiles = [{
-        name: extractedFiles[0].name,
-        content: convertedContent
-      }];
+      // Replace the main file's content with the converted content.
+      // For multi-file packages (e.g. skills with references/, agents/, etc.),
+      // preserve every other file so the full directory tree is installed —
+      // only the main entry point needs format conversion; supporting files are
+      // copied verbatim by the multi-file install loop below. Collapsing to a
+      // single file here would silently drop all supporting files in the target
+      // format (the cause of codex installs only receiving SKILL.md).
+      if (extractedFiles.length === 1) {
+        extractedFiles = [{
+          name: extractedFiles[0].name,
+          content: convertedContent,
+        }];
+      } else {
+        extractedFiles = extractedFiles.map((file, index) =>
+          index === mainFileIndex
+            ? { ...file, content: convertedContent }
+            : file
+        );
+      }
 
       console.log(`   ✓ Converted from ${pkg.format} to ${format}`);
     }
@@ -1476,8 +1495,11 @@ export async function handleInstall(
 
       // Multi-file package - create directory for package
       // For Claude skills, destDir already includes package name, so use it directly
-      // For Cursor rules converted from Claude skills, use flat structure
-      const isCursorConversion = (effectiveFormat === 'cursor' && pkg.format === 'claude' && pkg.subtype === 'skill');
+      // For Cursor rules converted from Claude skills, use flat structure.
+      // Skip the Cursor .mdc rename when the skill is installed via progressive
+      // disclosure (.openskills/) — there it stays a SKILL.md, matching the
+      // single-file install path, and supporting files are preserved verbatim.
+      const isCursorConversion = (effectiveFormat === 'cursor' && pkg.format === 'claude' && pkg.subtype === 'skill') && !needsProgressiveDisclosureMulti;
       const nativeSubtypeConfig = getSubtypeConfig(effectiveFormat, effectiveSubtype);
       const usesNativePackageSubdirectory = !needsProgressiveDisclosureMulti && Boolean(nativeSubtypeConfig?.usesPackageSubdirectory);
       const packageDir = (effectiveFormat === 'claude' && effectiveSubtype === 'skill')


### PR DESCRIPTION
## **User description**
## Problem

Installing a multi-file package to a converted format drops every file except the main entry point. For example:

```
prpm install @agent-relay/creating-cloud-persona --as claude,codex
```

- **claude** (native, no conversion) → full tree: `SKILL.md` + `references/` + `agents/` + `workforce/` …
- **codex** (converted) → only `.agents/skills/<name>/SKILL.md`

## Root cause

In `packages/cli/src/commands/install.ts`, the `--as` conversion path converted only the main file and then replaced the entire extracted file list with that single file:

```typescript
extractedFiles = [{ name: extractedFiles[0].name, content: convertedContent }];
```

All supporting files were discarded before the file-writing loop ran. The native install never converts, which is why only the converted target was affected.

## Fix

- Convert only the main entry point; keep all other files verbatim. The package stays multi-file and flows through the existing multi-file install loop, which writes the full tree to the target's location (`.agents/skills/<name>/` for codex, with subdirectories preserved).
- Single-file packages are unchanged.
- Guard the Cursor `.mdc` rename against progressive-disclosure skills so converted skills installed to `.openskills/` keep their `SKILL.md` name and supporting files, matching the single-file install path.

Supporting files are copied as-is rather than symlinked: codex's `SKILL.md` is regenerated by the converter (frontmatter normalized, body rebuilt), so a directory symlink to the claude copy would point codex at the un-converted file. The support files are identical either way.

## Tests

- New regression test: converting a multi-file claude skill `--as codex` now writes all files to `.agents/skills/<name>/` with subdirectories preserved.
- Updated the existing cursor progressive-disclosure test to assert supporting files are preserved (it previously asserted the old drop-files behavior).
- All 12 multi-file install tests pass; `tsc --noEmit` is clean. The 2 failing tests in `publish.test.ts` are pre-existing on `main` and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pr-pm/prpm/pull/272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Keep supporting files when converting multi-file installs**

### What Changed
- Installing a multi-file package with `--as` now keeps all supporting files instead of dropping everything except the main file.
- The converted main file is still written in the target format, while files like `helpers/` and `references/` stay in place under the same package folder.
- Cursor installs from Claude skills now keep the main file name and supporting files when using progressive disclosure, instead of renaming or discarding them.
- Added regression coverage for both Codex conversion and Cursor installs to confirm all files are preserved.

### Impact
`✅ Preserved skill bundles during format conversion`
`✅ Fewer missing-file installs for Codex skills`
`✅ Clearer Cursor skill installs with supporting files intact`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
